### PR TITLE
ADSPK-1. Added DISPLAY_ENTRIES_COUNT parameter.

### DIFF
--- a/server/src/main/scala/org/apache/livy/LivyConf.scala
+++ b/server/src/main/scala/org/apache/livy/LivyConf.scala
@@ -169,6 +169,9 @@ object LivyConf {
    */
   val SPARK_FILE_LISTS = Entry("livy.spark.file-list-configs", null)
 
+  // Max display entries in UI
+  val DISPLAY_ENTRIES_COUNT = Entry("livy.server.display-entries-count",100)
+
   private val HARDCODED_SPARK_FILE_LISTS = Seq(
     SPARK_JARS,
     SPARK_FILES,

--- a/server/src/main/scala/org/apache/livy/server/SessionServlet.scala
+++ b/server/src/main/scala/org/apache/livy/server/SessionServlet.scala
@@ -17,12 +17,13 @@
 
 package org.apache.livy.server
 
-import javax.servlet.http.HttpServletRequest
+import org.apache.livy.LivyConf.DISPLAY_ENTRIES_COUNT
 
+import javax.servlet.http.HttpServletRequest
 import org.scalatra._
+
 import scala.concurrent._
 import scala.concurrent.duration._
-
 import org.apache.livy.{LivyConf, Logging}
 import org.apache.livy.rsc.RSCClientFactory
 import org.apache.livy.server.batch.BatchSession
@@ -69,7 +70,7 @@ abstract class SessionServlet[S <: Session, R <: RecoveryMetadata](
 
   get("/") {
     val from = params.get("from").map(_.toInt).getOrElse(0)
-    val size = params.get("size").map(_.toInt).getOrElse(100)
+    val size = params.get("size").map(_.toInt).getOrElse(livyConf.getInt(DISPLAY_ENTRIES_COUNT))
 
     val sessions = sessionManager.all()
 


### PR DESCRIPTION
ADSPK-1. Added DISPLAY_ENTRIES_COUNT parameter to define the number of entries displayed in UI.

https://arenadata.atlassian.net/browse/ADSPK-1
https://issues.apache.org/jira/browse/LIVY-766
